### PR TITLE
Start modular skeleton with plugin loader

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+pgtool.log

--- a/README.md
+++ b/README.md
@@ -1,0 +1,21 @@
+# PGTool Modular Skeleton
+
+This repository starts the migration of the original `pgtool2.sh` script into a
+modular architecture.
+
+## Structure
+
+- `bin/pgtool.sh` – main entry point and menu loader.
+- `lib/` – reusable libraries (`colors.sh`, `log.sh`, `utils.sh`).
+- `plugins/` – dynamically loaded extensions.
+
+## Usage
+
+Run the tool via:
+
+```bash
+./bin/pgtool.sh
+```
+
+Plugins placed under `plugins/` with a `plugin_register` function are loaded
+automatically. An example plugin is provided in `plugins/ejemplo_hello.sh`.

--- a/bin/pgtool.sh
+++ b/bin/pgtool.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+# Main launcher for PGTool
+
+PGTOOL_HOME="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+export PGTOOL_HOME
+
+source "$PGTOOL_HOME/lib/colors.sh"
+source "$PGTOOL_HOME/lib/log.sh"
+source "$PGTOOL_HOME/lib/utils.sh"
+
+plugins_menu_entries=()
+plugins_callbacks=()
+
+load_plugins() {
+    local plugin
+    for plugin in "$PGTOOL_HOME/plugins"/*.sh; do
+        [[ -f "$plugin" ]] || continue
+        source "$plugin"
+        if declare -f plugin_register >/dev/null; then
+            local reg_output
+            reg_output=$(plugin_register)
+            eval "$reg_output"
+            plugins_menu_entries+=("${PLUGIN[menu_entry]}")
+            plugins_callbacks+=("${PLUGIN[callback]}")
+            unset PLUGIN
+        fi
+    done
+}
+
+show_menu() {
+    echo -e "${MAGENTA}${BOLD}PGTool${NC}"
+    local i=1
+    for entry in "${plugins_menu_entries[@]}"; do
+        echo -e "${CYAN}${BOLD}$i)${NC} ${WHITE}$entry${NC}"
+        ((i++))
+    done
+    echo -e "${CYAN}${BOLD}0)${NC} ${WHITE}Exit${NC}"
+}
+
+main() {
+    load_plugins
+    log::init "$PGTOOL_HOME/pgtool.log"
+    while true; do
+        show_menu
+        read -p "Select option: " opt
+        if [[ "$opt" == "0" ]]; then
+            break
+        elif [[ "$opt" =~ ^[0-9]+$ && $opt -ge 1 && $opt -le ${#plugins_callbacks[@]} ]]; then
+            local cb="${plugins_callbacks[$((opt-1))]}"
+            "$cb"
+        else
+            echo "Invalid option"
+        fi
+    done
+}
+
+main "$@"

--- a/lib/colors.sh
+++ b/lib/colors.sh
@@ -1,0 +1,16 @@
+# Color definitions
+NC='\033[0m'
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[0;33m'
+CYAN='\033[0;36m'
+MAGENTA='\033[0;35m'
+WHITE='\033[0;37m'
+BOLD='\033[1m'
+UNDERLINE='\033[4m'
+
+CHECK="${GREEN}✔${NC}"
+FAIL="${RED}✗${NC}"
+ARROW="${CYAN}➜${NC}"
+INFO="${CYAN}ℹ${NC}"
+WARN="${YELLOW}⚠${NC}"

--- a/lib/log.sh
+++ b/lib/log.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+# Basic logging utility
+
+log_file=""
+
+log::init() {
+    local file="$1"
+    log_file="$file"
+    mkdir -p "$(dirname "$log_file")"
+    touch "$log_file"
+}
+
+log::_write() {
+    local level="$1" msg="$2"
+    local ts
+    ts=$(date '+%Y-%m-%d %H:%M:%S')
+    echo "[$ts][$level] $msg" >> "$log_file"
+}
+
+log::info() { log::_write INFO "$*"; }
+log::warn() { log::_write WARN "$*"; }
+log::error() { log::_write ERROR "$*"; }

--- a/lib/utils.sh
+++ b/lib/utils.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+# Generic helper functions
+
+utils::read_num() {
+    local prompt="$1" default="$2" re='^[0-9]+$' val
+    while true; do
+        read -p "$prompt" val
+        val=${val:-$default}
+        [[ "$val" =~ $re ]] && { echo "$val"; return 0; }
+        echo "Invalid number" >&2
+    done
+}

--- a/plugins/ejemplo_hello.sh
+++ b/plugins/ejemplo_hello.sh
@@ -1,0 +1,15 @@
+## Plugin de demostración
+plugin_register() {
+  declare -A PLUGIN=(
+    [name]="hello"
+    [description]="Muestra un saludo de prueba"
+    [menu_entry]="Saludar"
+    [callback]="hello::run"
+  )
+  echo "$(declare -p PLUGIN)"
+}
+
+hello::run() {
+  echo "Hola desde un plugin!"
+  return 0
+}


### PR DESCRIPTION
## Summary
- begin migration towards modular architecture
- add `bin/pgtool.sh` entrypoint with plugin loader
- provide basic libraries for colors, logging and utils
- implement sample plugin `ejemplo_hello.sh`
- add README with usage instructions

## Testing
- `./bin/pgtool.sh <<EOF
0
EOF`
- `./bin/pgtool.sh <<EOF
1
0
EOF`
- `shellcheck bin/pgtool.sh lib/log.sh lib/utils.sh plugins/ejemplo_hello.sh`

------
https://chatgpt.com/codex/tasks/task_e_685a8ae9d4008320863a84639c62f514