### PR TITLE
Start modular skeleton with plugin loader

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+pgtool.log

--- a/README.md
+++ b/README.md
@@ -1,0 +1,23 @@
+# PGTool Modular Skeleton
+
+This repository starts the migration of the original `pgtool2.sh` script into a
+modular architecture.
+
+## Structure
+
+- `bin/pgtool.sh` – main entry point and menu loader.
+- `lib/` – reusable libraries (`colors.sh`, `log.sh`, `utils.sh`, `pgpass.sh`).
+- `plugins/` – dynamically loaded extensions. Includes a sample `ejemplo_hello.sh`
+  and a `.pgpass` management plugin.
+
+## Usage
+
+Run the tool via:
+
+```bash
+./bin/pgtool.sh
+```
+
+Plugins placed under `plugins/` with a `plugin_register` function are loaded
+automatically. Sample plugins are provided in `plugins/ejemplo_hello.sh` and
+`plugins/pgpass_manage.sh`.

--- a/bin/pgtool.sh
+++ b/bin/pgtool.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+# Main launcher for PGTool
+set -euo pipefail
+
+PGTOOL_HOME="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+export PGTOOL_HOME
+
+source "$PGTOOL_HOME/lib/colors.sh"
+source "$PGTOOL_HOME/lib/log.sh"
+source "$PGTOOL_HOME/lib/utils.sh"
+
+plugins_menu_entries=()
+plugins_callbacks=()
+
+load_plugins() {
+    local plugin
+    for plugin in "$PGTOOL_HOME/plugins"/*.sh; do
+        [[ -f "$plugin" ]] || continue
+        source "$plugin"
+        if declare -f plugin_register >/dev/null; then
+            local reg_output
+            reg_output=$(plugin_register)
+            eval "$reg_output"
+            plugins_menu_entries+=("${PLUGIN[menu_entry]}")
+            plugins_callbacks+=("${PLUGIN[callback]}")
+            unset PLUGIN
+            unset -f plugin_register
+        fi
+    done
+}
+
+show_menu() {
+    echo -e "${MAGENTA}${BOLD}PGTool${NC}"
+    local i=1
+    for entry in "${plugins_menu_entries[@]}"; do
+        echo -e "${CYAN}${BOLD}$i)${NC} ${WHITE}$entry${NC}"
+        ((i++))
+    done
+    echo -e "${CYAN}${BOLD}0)${NC} ${WHITE}Exit${NC}"
+}
+
+main() {
+    load_plugins
+    log::init "$PGTOOL_HOME/pgtool.log"
+    while true; do
+        show_menu
+        read -r -p "Select option: " opt
+        if [[ "$opt" == "0" ]]; then
+            break
+        elif [[ "$opt" =~ ^[0-9]+$ && $opt -ge 1 && $opt -le ${#plugins_callbacks[@]} ]]; then
+            local cb="${plugins_callbacks[$((opt-1))]}"
+            "$cb"
+        else
+            echo "Invalid option"
+        fi
+    done
+}
+
+main "$@"

--- a/lib/colors.sh
+++ b/lib/colors.sh
@@ -1,0 +1,16 @@
+# Color definitions
+NC='\033[0m'
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[0;33m'
+CYAN='\033[0;36m'
+MAGENTA='\033[0;35m'
+WHITE='\033[0;37m'
+BOLD='\033[1m'
+UNDERLINE='\033[4m'
+
+CHECK="${GREEN}✔${NC}"
+FAIL="${RED}✗${NC}"
+ARROW="${CYAN}➜${NC}"
+INFO="${CYAN}ℹ${NC}"
+WARN="${YELLOW}⚠${NC}"

--- a/lib/log.sh
+++ b/lib/log.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+# Basic logging utility
+
+log_file=""
+
+log::init() {
+    local file="$1"
+    log_file="$file"
+    mkdir -p "$(dirname "$log_file")"
+    touch "$log_file"
+}
+
+log::_write() {
+    local level="$1" msg="$2"
+    local ts
+    ts=$(date '+%Y-%m-%d %H:%M:%S')
+    echo "[$ts][$level] $msg" >> "$log_file"
+}
+
+log::info() { log::_write INFO "$*"; }
+log::warn() { log::_write WARN "$*"; }
+log::error() { log::_write ERROR "$*"; }

--- a/lib/pgpass.sh
+++ b/lib/pgpass.sh
@@ -1,0 +1,95 @@
+#!/bin/bash
+# ~/.pgpass management functions
+
+pgpass::file() {
+    echo "$HOME/.pgpass"
+}
+
+pgpass::ensure() {
+    local pgp
+    pgp="$(pgpass::file)"
+    [[ -f "$pgp" ]] || touch "$pgp"
+    chmod 600 "$pgp"
+}
+
+pgpass::list() {
+    local pgp
+    pgp="$(pgpass::file)"
+    mapfile -t lines < "$pgp"
+    if (( ${#lines[@]} == 0 )); then
+        echo "No entries found"
+        return 0
+    fi
+    local i
+    for i in "${!lines[@]}"; do
+        printf "%2d) %s\n" "$i" "${lines[$i]}"
+    done
+}
+
+pgpass::add() {
+    pgpass::ensure
+    local host port db user pass line
+    read -r -p "Host: " host
+    read -r -p "Port [5432]: " port
+    port=${port:-5432}
+    read -r -p "Database [*]: " db
+    db=${db:-*}
+    read -r -p "User: " user
+    read -r -s -p "Password: " pass
+    echo
+    line="${host}:${port}:${db}:${user}:${pass}"
+    local pgp
+    pgp="$(pgpass::file)"
+    if grep -Fqx "$line" "$pgp"; then
+        echo "Entry already exists"
+        return 1
+    fi
+    echo "$line" >> "$pgp"
+    echo "Added"
+}
+
+pgpass::delete() {
+    local idx pgp
+    pgp="$(pgpass::file)"
+    pgpass::list
+    read -r -p "Index to delete: " idx
+    sed -i "${idx}d" "$pgp"
+    echo "Deleted"
+}
+
+pgpass::edit() {
+    local idx pgp host port db user pass
+    pgp="$(pgpass::file)"
+    pgpass::list
+    read -r -p "Index to edit: " idx
+    IFS=: read -r host port db user pass < <(sed -n "${idx}p" "$pgp")
+    read -r -p "Host [$host]: " tmp; host=${tmp:-$host}
+    read -r -p "Port [$port]: " tmp; port=${tmp:-$port}
+    read -r -p "Database [$db]: " tmp; db=${tmp:-$db}
+    read -r -p "User [$user]: " tmp; user=${tmp:-$user}
+    read -r -s -p "Password [hidden]: " tmp; echo; pass=${tmp:-$pass}
+    sed -i "${idx}c ${host}:${port}:${db}:${user}:${pass}" "$pgp"
+    echo "Updated"
+}
+
+pgpass::menu() {
+    pgpass::ensure
+    while true; do
+        echo "--- .pgpass Menu ---"
+        echo "1) List entries"
+        echo "2) Add entry"
+        echo "3) Edit entry"
+        echo "4) Delete entry"
+        echo "0) Back"
+        read -r -p "Choose: " opt
+        case "$opt" in
+            1) pgpass::list ;;
+            2) pgpass::add ;;
+            3) pgpass::edit ;;
+            4) pgpass::delete ;;
+            0) break ;;
+            *) echo "Invalid" ;;
+        esac
+    done
+}
+

--- a/lib/utils.sh
+++ b/lib/utils.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+# Generic helper functions
+
+utils::read_num() {
+    local prompt="$1" default="$2" re='^[0-9]+$' val
+    while true; do
+        read -r -p "$prompt" val
+        val=${val:-$default}
+        [[ "$val" =~ $re ]] && { echo "$val"; return 0; }
+        echo "Invalid number" >&2
+    done
+}

--- a/plugins/ejemplo_hello.sh
+++ b/plugins/ejemplo_hello.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+## Plugin de demostración
+plugin_register() {
+  declare -A PLUGIN=(
+    [name]="hello"
+    [description]="Muestra un saludo de prueba"
+    [menu_entry]="Saludar"
+    [callback]="hello::run"
+  )
+  declare -p PLUGIN
+}
+
+hello::run() {
+  echo "Hola desde un plugin!"
+  return 0
+}

--- a/plugins/pgpass_manage.sh
+++ b/plugins/pgpass_manage.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+## Plugin for .pgpass management
+plugin_register() {
+  declare -A PLUGIN=(
+    [name]="pgpass"
+    [description]="Manage ~/.pgpass entries"
+    [menu_entry]="Manage .pgpass"
+    [callback]="pgpass::menu"
+  )
+  declare -p PLUGIN
+}
+
+source "$PGTOOL_HOME/lib/pgpass.sh"


### PR DESCRIPTION
## Summary
- begin migration towards modular architecture
- add `bin/pgtool.sh` entrypoint with plugin loader
- provide basic libraries for colors, logging and utils
- implement sample plugin `ejemplo_hello.sh`
- add `.pgpass` management library and plugin
- update README with plugin info

## Testing
- `./bin/pgtool.sh <<'EOF'
0
EOF`
- `./bin/pgtool.sh <<'EOF'
1
0
EOF`
- `./bin/pgtool.sh <<'EOF'
2
0
EOF`
- `shellcheck bin/pgtool.sh lib/log.sh lib/utils.sh lib/pgpass.sh plugins/ejemplo_hello.sh plugins/pgpass_manage.sh`


------
https://chatgpt.com/codex/tasks/task_e_685a8ae9d4008320863a84639c62f514