### PR TITLE
Start modular skeleton with plugin loader

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+pgtool.log

--- a/README.md
+++ b/README.md
@@ -1,0 +1,30 @@
+# PGTool Modular Skeleton
+
+This repository starts the migration of the original `pgtool2.sh` script into a modular architecture.
+
+## Structure
+
+- `bin/pgtool.sh` – main entry point and menu loader.
+- `lib/` – reusable libraries (`colors.sh`, `log.sh`, `utils.sh`, `pgpass.sh`,
+  `menu.sh`).
+- `plugins/` – dynamically loaded extensions. Includes a sample `ejemplo_hello.sh`
+  and a `.pgpass` management plugin. The `backup_core` plugin runs backups based
+  on `etc/connections.json`.
+
+## Usage
+
+Run the tool via:
+
+```bash
+./bin/pgtool.sh
+```
+
+Plugins placed under `plugins/` with a `plugin_register` function are loaded automatically. Sample plugins are provided in `plugins/ejemplo_hello.sh` and `plugins/pgpass_manage.sh`.
+
+Backups can be triggered from the `backup_core` plugin, which reads connection
+information from `etc/connections.json` using `lib/config.sh`.
+
+An additional plugin `plugins/backup_logical.sh` demonstrates how to call the
+new logical backup module under `modules/backup/`.
+
+A legacy backup menu is available via the `legacy_backup` plugin, which simply runs the original `pgtool2.sh` script. Place `pgtool2.sh` at the project root (already provided) and choose **Legacy Backup Menu** from the main launcher.

--- a/bin/pgtool.sh
+++ b/bin/pgtool.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+# Main launcher for PGTool
+set -euo pipefail
+
+PGTOOL_HOME="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+export PGTOOL_HOME
+
+# shellcheck source=lib/colors.sh
+source "$PGTOOL_HOME/lib/colors.sh"
+# shellcheck source=lib/log.sh
+source "$PGTOOL_HOME/lib/log.sh"
+# shellcheck source=lib/utils.sh
+source "$PGTOOL_HOME/lib/utils.sh"
+# shellcheck source=lib/menu.sh
+source "$PGTOOL_HOME/lib/menu.sh"
+
+plugins_menu_entries=()
+plugins_callbacks=()
+
+load_plugins() {
+    local plugin
+    for plugin in "$PGTOOL_HOME/plugins"/*.sh; do
+        [[ -f "$plugin" ]] || continue
+        # shellcheck source=/dev/null
+        source "$plugin"
+        if declare -f plugin_register >/dev/null; then
+            local reg_output
+            reg_output=$(plugin_register)
+            eval "$reg_output"
+            plugins_menu_entries+=("${PLUGIN[menu_entry]}")
+            plugins_callbacks+=("${PLUGIN[callback]}")
+            unset PLUGIN
+            unset -f plugin_register
+        fi
+    done
+}
+
+show_menu() {
+    menu::prompt "PGTool" plugins_menu_entries
+}
+
+main() {
+    load_plugins
+    log::init "$PGTOOL_HOME/pgtool.log"
+    while true; do
+        local opt
+        opt=$(show_menu)
+        if [[ "$opt" == "0" ]]; then
+            break
+        fi
+        local cb="${plugins_callbacks[$((opt-1))]}"
+        "$cb"
+    done
+}
+
+main "$@"

--- a/etc/connections.json
+++ b/etc/connections.json
@@ -1,0 +1,3 @@
+[
+  {"host": "localhost", "port": 5432, "user": "postgres", "database": "postgres"}
+]

--- a/lib/colors.sh
+++ b/lib/colors.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+# Color definitions
+NC='\033[0m'
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[0;33m'
+CYAN='\033[0;36m'
+MAGENTA='\033[0;35m'
+WHITE='\033[0;37m'
+BOLD='\033[1m'
+UNDERLINE='\033[4m'
+
+CHECK="${GREEN}✔${NC}"
+FAIL="${RED}✗${NC}"
+ARROW="${CYAN}➜${NC}"
+INFO="${CYAN}ℹ${NC}"
+WARN="${YELLOW}⚠${NC}"

--- a/lib/config.sh
+++ b/lib/config.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+# Configuration loading utilities (no jq)
+
+config::file() {
+    echo "$PGTOOL_HOME/etc/connections.json"
+}
+
+# load configuration into arrays
+config::load() {
+    local conf
+    conf="$(config::file)"
+    HOSTS=()
+    PORTS=()
+    USERS=()
+    DBS=()
+    [[ -f "$conf" ]] || return 0
+    local entry key value
+    while IFS= read -r line; do
+        line="${line#*[{]}"  # remove leading chars until {
+        line="${line%*]}"    # remove trailing chars after ]
+        [[ -z "$line" ]] && continue
+        # split by "}," boundaries
+        echo "$line" | tr -d '\n' | sed 's/},{/\n/g' | while IFS= read -r obj; do
+            host=$(echo "$obj" | sed -n 's/.*"host"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p')
+            port=$(echo "$obj" | sed -n 's/.*"port"[[:space:]]*:[[:space:]]*\([0-9]*\).*/\1/p')
+            user=$(echo "$obj" | sed -n 's/.*"user"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p')
+            db=$(echo "$obj" | sed -n 's/.*"database"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p')
+            HOSTS+=("$host")
+            PORTS+=("${port:-5432}")
+            USERS+=("$user")
+            DBS+=("$db")
+        done
+    done < "$conf"
+}

--- a/lib/log.sh
+++ b/lib/log.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+# Basic logging utility
+
+log_file=""
+
+log::init() {
+    local file="$1"
+    log_file="$file"
+    mkdir -p "$(dirname "$log_file")"
+    touch "$log_file"
+}
+
+log::_write() {
+    local level="$1" msg="$2"
+    local ts
+    ts=$(date '+%Y-%m-%d %H:%M:%S')
+    echo "[$ts][$level] $msg" >> "$log_file"
+}
+
+log::info() { log::_write INFO "$*"; }
+log::warn() { log::_write WARN "$*"; }
+log::error() { log::_write ERROR "$*"; }

--- a/lib/menu.sh
+++ b/lib/menu.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+# Simple menu rendering helpers
+
+menu::prompt() {
+  local title="$1" arr_name="$2" prompt="${3:-Select option: }"
+  local -n arr="$arr_name"
+  echo -e "${MAGENTA}${BOLD}${title}${NC}" >&2
+  local i=1
+  for entry in "${arr[@]}"; do
+    echo -e "${CYAN}${BOLD}${i})${NC} ${WHITE}${entry}${NC}" >&2
+    ((i++))
+  done
+  echo -e "${CYAN}${BOLD}0)${NC} ${WHITE}Exit${NC}" >&2
+  local opt
+  while true; do
+    read -r -p "$prompt" opt
+    if [[ "$opt" =~ ^[0-9]+$ && $opt -ge 0 && $opt -le ${#arr[@]} ]]; then
+      echo "$opt"
+      return 0
+    fi
+    echo "Invalid option" >&2
+  done
+}

--- a/lib/pgpass.sh
+++ b/lib/pgpass.sh
@@ -1,0 +1,94 @@
+#!/bin/bash
+# ~/.pgpass management functions
+
+pgpass::file() {
+    echo "$HOME/.pgpass"
+}
+
+pgpass::ensure() {
+    local pgp
+    pgp="$(pgpass::file)"
+    [[ -f "$pgp" ]] || touch "$pgp"
+    chmod 600 "$pgp"
+}
+
+pgpass::list() {
+    local pgp
+    pgp="$(pgpass::file)"
+    mapfile -t lines < "$pgp"
+    if (( ${#lines[@]} == 0 )); then
+        echo "No entries found"
+        return 0
+    fi
+    local i
+    for i in "${!lines[@]}"; do
+        printf "%2d) %s\n" "$i" "${lines[$i]}"
+    done
+}
+
+pgpass::add() {
+    pgpass::ensure
+    local host port db user pass line
+    read -r -p "Host: " host
+    read -r -p "Port [5432]: " port
+    port=${port:-5432}
+    read -r -p "Database [*]: " db
+    db=${db:-*}
+    read -r -p "User: " user
+    read -r -s -p "Password: " pass
+    echo
+    line="${host}:${port}:${db}:${user}:${pass}"
+    local pgp
+    pgp="$(pgpass::file)"
+    if grep -Fqx "$line" "$pgp"; then
+        echo "Entry already exists"
+        return 1
+    fi
+    echo "$line" >> "$pgp"
+    echo "Added"
+}
+
+pgpass::delete() {
+    local idx pgp
+    pgp="$(pgpass::file)"
+    pgpass::list
+    read -r -p "Index to delete: " idx
+    sed -i "${idx}d" "$pgp"
+    echo "Deleted"
+}
+
+pgpass::edit() {
+    local idx pgp host port db user pass
+    pgp="$(pgpass::file)"
+    pgpass::list
+    read -r -p "Index to edit: " idx
+    IFS=: read -r host port db user pass < <(sed -n "${idx}p" "$pgp")
+    read -r -p "Host [$host]: " tmp; host=${tmp:-$host}
+    read -r -p "Port [$port]: " tmp; port=${tmp:-$port}
+    read -r -p "Database [$db]: " tmp; db=${tmp:-$db}
+    read -r -p "User [$user]: " tmp; user=${tmp:-$user}
+    read -r -s -p "Password [hidden]: " tmp; echo; pass=${tmp:-$pass}
+    sed -i "${idx}c ${host}:${port}:${db}:${user}:${pass}" "$pgp"
+    echo "Updated"
+}
+
+pgpass::menu() {
+    pgpass::ensure
+    while true; do
+        echo "--- .pgpass Menu ---"
+        echo "1) List entries"
+        echo "2) Add entry"
+        echo "3) Edit entry"
+        echo "4) Delete entry"
+        echo "0) Back"
+        read -r -p "Choose: " opt
+        case "$opt" in
+            1) pgpass::list ;;
+            2) pgpass::add ;;
+            3) pgpass::edit ;;
+            4) pgpass::delete ;;
+            0) break ;;
+            *) echo "Invalid" ;;
+        esac
+    done
+}

--- a/lib/utils.sh
+++ b/lib/utils.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+# Generic helper functions
+
+utils::read_num() {
+    local prompt="$1" default="$2" re='^[0-9]+$' val
+    while true; do
+        read -r -p "$prompt" val
+        val=${val:-$default}
+        [[ "$val" =~ $re ]] && { echo "$val"; return 0; }
+        echo "Invalid number" >&2
+    done
+}

--- a/modules/backup/core.sh
+++ b/modules/backup/core.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+# Core backup orchestration using pg_dump
+
+# shellcheck source=../../lib/config.sh
+source "$PGTOOL_HOME/lib/config.sh"
+
+backup_core::run_all() {
+    config::load
+    local i
+    for i in "${!HOSTS[@]}"; do
+        backup_core::run_one "${HOSTS[i]}" "${PORTS[i]}" "${DBS[i]}" "${USERS[i]}"
+    done
+}
+
+backup_core::run_one() {
+    local host="$1" port="$2" db="$3" user="$4"
+    [[ -z "$host" || -z "$db" || -z "$user" ]] && return
+    mkdir -p "$PGTOOL_HOME/backups"
+    local out="$PGTOOL_HOME/backups/${db}_$(date +%Y%m%d_%H%M%S).sql"
+    pg_dump -h "$host" -p "$port" -U "$user" "$db" > "$out"
+    echo "Saved $out"
+}
+
+backup_core::menu() {
+    backup_core::run_all
+    read -r -p "Press enter to continue" _
+}

--- a/modules/backup/logical.sh
+++ b/modules/backup/logical.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+# Basic logical backup module
+
+backup_logical::menu() {
+  local host db user port
+  read -r -p "Host: " host
+  read -r -p "Port [5432]: " port
+  port=${port:-5432}
+  read -r -p "Database: " db
+  read -r -p "User: " user
+  backup_logical::run "$host" "$port" "$db" "$user"
+}
+
+backup_logical::run() {
+  local host="$1" port="$2" db="$3" user="$4"
+  if ! command -v pg_dump >/dev/null; then
+    echo "pg_dump not found" >&2
+    return 1
+  fi
+  local dir="$PGTOOL_HOME/backups"
+  mkdir -p "$dir"
+  local out
+  out="$dir/${db}_$(date +%Y%m%d_%H%M%S).sql"
+  PGPASSWORD="" pg_dump -h "$host" -p "$port" -U "$user" "$db" > "$out"
+  echo "Backup saved to $out"
+}

--- a/plugins/backup_core.sh
+++ b/plugins/backup_core.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+# Plugin to run backups from configuration
+plugin_register() {
+  declare -A PLUGIN=(
+    [name]="backup_core"
+    [description]="Run backups for all configured databases"
+    [menu_entry]="Run Configured Backups"
+    [callback]="backup_core::menu"
+  )
+  declare -p PLUGIN
+}
+
+source "$PGTOOL_HOME/modules/backup/core.sh"

--- a/plugins/backup_logical.sh
+++ b/plugins/backup_logical.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+## Plugin to run simple logical backups
+plugin_register() {
+  declare -A PLUGIN=(
+    [name]="logical_backup"
+    [description]="Run a simple pg_dump backup"
+    [menu_entry]="Run Logical Backup"
+    [callback]="backup_logical::menu"
+  )
+  declare -p PLUGIN
+}
+
+source "$PGTOOL_HOME/modules/backup/logical.sh"

--- a/plugins/ejemplo_hello.sh
+++ b/plugins/ejemplo_hello.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+## Plugin de demostración
+plugin_register() {
+  declare -A PLUGIN=(
+    [name]="hello"
+    [description]="Muestra un saludo de prueba"
+    [menu_entry]="Saludar"
+    [callback]="hello::run"
+  )
+  declare -p PLUGIN
+}
+
+hello::run() {
+  echo "Hola desde un plugin!"
+  return 0
+}

--- a/plugins/legacy_backup.sh
+++ b/plugins/legacy_backup.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+## Plugin to run legacy pgtool2.sh script
+plugin_register() {
+  declare -A PLUGIN=(
+    [name]="legacy_backup"
+    [description]="Run legacy pgtool2.sh backup menu"
+    [menu_entry]="Legacy Backup Menu"
+    [callback]="legacy_backup::run"
+  )
+  declare -p PLUGIN
+}
+
+legacy_backup::run() {
+  bash "$PGTOOL_HOME/pgtool2.sh"
+}

--- a/plugins/pgpass_manage.sh
+++ b/plugins/pgpass_manage.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+## Plugin for .pgpass management
+plugin_register() {
+  declare -A PLUGIN=(
+    [name]="pgpass"
+    [description]="Manage ~/.pgpass entries"
+    [menu_entry]="Manage .pgpass"
+    [callback]="pgpass::menu"
+  )
+  declare -p PLUGIN
+}
+
+source "$PGTOOL_HOME/lib/pgpass.sh"

--- a/primero.txt
+++ b/primero.txt
@@ -1,1 +1,0 @@
-Primer ficherillo


### PR DESCRIPTION
## Summary
- reapply modular skeleton without conflicts
- restore plugin loader and basic libs
- include sample plugins and legacy backup wrapper
- provide README with usage info
- add menu library and simple logical backup module
- add config loader and backup core plugin for running pg_dump using a JSON config

## Testing
- `./bin/pgtool.sh <<'EOF'
0
EOF`
- `shellcheck -x bin/pgtool.sh lib/*.sh plugins/*.sh modules/backup/*.sh | head -n 5`


------
https://chatgpt.com/codex/tasks/task_e_685a8ae9d4008320863a84639c62f514