### PR TITLE
Fix 1-based index usage for pgpass edits

### DIFF
--- a/lib/pgpass.sh
+++ b/lib/pgpass.sh
@@ -49,26 +49,38 @@ pgpass::add() {
 }
 
 pgpass::delete() {
-    local idx pgp
+    local idx pgp line_num
     pgp="$(pgpass::file)"
     pgpass::list
     read -r -p "Index to delete: " idx
-    sed -i "${idx}d" "$pgp"
+    mapfile -t lines < "$pgp"
+    if (( idx < 0 || idx >= ${#lines[@]} )); then
+        echo "Invalid index"
+        return 1
+    fi
+    line_num=$((idx + 1))
+    sed -i "${line_num}d" "$pgp"
     echo "Deleted"
 }
 
 pgpass::edit() {
-    local idx pgp host port db user pass
+    local idx pgp host port db user pass line_num
     pgp="$(pgpass::file)"
     pgpass::list
     read -r -p "Index to edit: " idx
-    IFS=: read -r host port db user pass < <(sed -n "${idx}p" "$pgp")
+    mapfile -t lines < "$pgp"
+    if (( idx < 0 || idx >= ${#lines[@]} )); then
+        echo "Invalid index"
+        return 1
+    fi
+    line_num=$((idx + 1))
+    IFS=: read -r host port db user pass < <(sed -n "${line_num}p" "$pgp")
     read -r -p "Host [$host]: " tmp; host=${tmp:-$host}
     read -r -p "Port [$port]: " tmp; port=${tmp:-$port}
     read -r -p "Database [$db]: " tmp; db=${tmp:-$db}
     read -r -p "User [$user]: " tmp; user=${tmp:-$user}
     read -r -s -p "Password [hidden]: " tmp; echo; pass=${tmp:-$pass}
-    sed -i "${idx}c ${host}:${port}:${db}:${user}:${pass}" "$pgp"
+    sed -i "${line_num}c ${host}:${port}:${db}:${user}:${pass}" "$pgp"
     echo "Updated"
 }
 


### PR DESCRIPTION
## Summary
- validate index when editing or deleting pgpass entries
- convert 0-based index to 1-based line numbers for sed commands

## Testing
- `bash -c 'source lib/pgpass.sh; export HOME=$(mktemp -d); echo "entry1" > $HOME/.pgpass; echo "entry2" >> $HOME/.pgpass; { echo 0; } | pgpass::delete && cat $HOME/.pgpass'`
- `bash -c 'source lib/pgpass.sh; export HOME=$(mktemp -d); echo "e1" > $HOME/.pgpass; echo "e2" >> $HOME/.pgpass; { echo 0; echo newhost; echo 1234; echo newdb; echo newuser; echo newpass; } | pgpass::edit && cat $HOME/.pgpass'`


------
https://chatgpt.com/codex/tasks/task_e_685aaf978afc8320b11967ea6455485b